### PR TITLE
fix: Sqlx SQLite expiring sessions at wrong time

### DIFF
--- a/sqlx-store/src/mysql_store.rs
+++ b/sqlx-store/src/mysql_store.rs
@@ -22,7 +22,7 @@ impl MySqlStore {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use tower_sessions_sqlx::{sqlx::MySqlPool, MySqlStore};
+    /// use tower_sessions_sqlx_store::{sqlx::MySqlPool, MySqlStore};
     ///
     /// # tokio_test::block_on(async {
     /// let database_url = std::option_env!("DATABASE_URL").unwrap();
@@ -75,7 +75,7 @@ impl MySqlStore {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use tower_sessions_sqlx::{sqlx::MySqlPool, MySqlStore};
+    /// use tower_sessions_sqlx_store::{sqlx::MySqlPool, MySqlStore};
     ///
     /// # tokio_test::block_on(async {
     /// let database_url = std::option_env!("DATABASE_URL").unwrap();

--- a/sqlx-store/src/sqlite_store.rs
+++ b/sqlx-store/src/sqlite_store.rs
@@ -116,7 +116,7 @@ impl ExpiredDeletion for SqliteStore {
         let query = format!(
             r#"
             delete from {table_name}
-            where expiry_date < datetime('now', 'utc')
+            WHERE datetime(expiry_date) < datetime('now')
             "#,
             table_name = self.table_name
         );


### PR DESCRIPTION
Fixes #9 

Implemented fix as per suggestion, casting _both_ the column value as well as the comparison value as `datetime`.

All tests passing, manual tests show the issue reported in #9 is no longer happening (sessions are correctly being removed on time).

Also fixes import locations in documentation to allow for all tests to pass:

```diff
-     /// use tower_sessions_sqlx::{sqlx::MySqlPool, MySqlStore};
+     /// use tower_sessions_sqlx_store::{sqlx::MySqlPool, MySqlStore};
```