### PR TITLE
sqlite optimizations

### DIFF
--- a/sqlx-store/src/sqlite_store.rs
+++ b/sqlx-store/src/sqlite_store.rs
@@ -55,12 +55,14 @@ impl SqliteStore {
     pub async fn migrate(&self) -> sqlx::Result<()> {
         let query = format!(
             r#"
-            create table if not exists {}
+            create table if not exists {0}
             (
                 id text primary key not null,
                 data blob not null,
                 expiry_date integer not null
-            )
+            ) without rowid;
+
+            create index if not exists {0}_expiry_date_idx on {0}(expiry_date)
             "#,
             self.table_name
         );


### PR DESCRIPTION
Creating new expiry key index as that's often used for lookups.

Adding "without rowid" to the table creation to reduce the size of this table on disk and improve lookup performance.

(Second PR.  First one had to close as the primary key was broken with the prior PR).