### PR TITLE
Support of sqlx/chrono

### DIFF
--- a/redis-store/src/lib.rs
+++ b/redis-store/src/lib.rs
@@ -59,7 +59,10 @@ impl<C: KeysInterface + Send + Sync> RedisStore<C> {
     /// })
     /// ```
     pub fn new(client: C) -> Self {
-        Self { client, prefix: None }
+        Self {
+            client,
+            prefix: None,
+        }
     }
 
     /// Create a new Redis store with the provided client and prefix.
@@ -79,7 +82,10 @@ impl<C: KeysInterface + Send + Sync> RedisStore<C> {
     /// })
     /// ```
     pub fn with_prefix(client: C, prefix: String) -> Self {
-        Self { client, prefix: Some(prefix) }
+        Self {
+            client,
+            prefix: Some(prefix),
+        }
     }
 
     fn get_key(&self, id: &Id) -> String {

--- a/sqlx-store/Cargo.toml
+++ b/sqlx-store/Cargo.toml
@@ -13,23 +13,37 @@ documentation = "https://docs.rs/tower-sessions-sqlx-store"
 readme = "README.md"
 
 [features]
+default = ["sqlx-time"]
+
+sqlx-time = [
+    "time",
+    "sqlx/time",
+]
+
+sqlx-chrono = [
+    "chrono",
+    "sqlx/chrono",
+]
+
 sqlite = ["sqlx/sqlite"]
 postgres = ["sqlx/postgres"]
 mysql = ["sqlx/mysql"]
 
 [dependencies]
-async-trait = "0.1.77"
-rmp-serde = "1.1.2"
-sqlx = { version = "0.8.0", features = ["time", "runtime-tokio"] }
-thiserror = "1.0.56"
-time = "0.3.31"
-tower-sessions-core = { version = "0.14.0", features = ["deletion-task"] }
+async-trait = "0.1"
+chrono = { version = "0.4", optional = true }
+rmp-serde = "1.3"
+sqlx = { version = "0.8", features = ["runtime-tokio"] }
+thiserror = "2.0"
+time = { version = "0.3", optional = true }
+tower-sessions-core = { version = "0.14", features = ["deletion-task"] }
 
 [dev-dependencies]
-axum = "0.8.1"
+axum = "0.8.4"
+time = { version = "0.3" }
 tower-sessions = "0.14.0"
-tokio = { version = "1.32.0", features = ["full"] }
-tokio-test = "0.4.3"
+tokio = { version = "1.46.1", features = ["full"] }
+tokio-test = "0.4.4"
 serde = "1"
 
 [[example]]

--- a/sqlx-store/src/lib.rs
+++ b/sqlx-store/src/lib.rs
@@ -1,5 +1,13 @@
+#![cfg(all(
+    any(feature = "sqlx-time", feature = "sqlx-chrono"),
+    not(all(feature = "sqlx-time", feature = "sqlx-chrono"))
+))]
+
 pub use sqlx;
 use tower_sessions_core::session_store;
+
+#[cfg(any(feature = "sqlite", feature = "postgres", feature = "mysql"))]
+mod time;
 
 #[cfg(feature = "mysql")]
 #[cfg_attr(docsrs, doc(cfg(feature = "mysql")))]

--- a/sqlx-store/src/mysql_store.rs
+++ b/sqlx-store/src/mysql_store.rs
@@ -1,11 +1,11 @@
 use async_trait::async_trait;
 use sqlx::{MySqlConnection, MySqlPool};
-use time::OffsetDateTime;
 use tower_sessions_core::{
     session::{Id, Record},
     session_store, ExpiredDeletion, SessionStore,
 };
 
+use crate::time::{now, ExpirationTime};
 use crate::SqlxStoreError;
 
 /// A MySQL session store.
@@ -147,7 +147,7 @@ impl MySqlStore {
         sqlx::query(&query)
             .bind(record.id.to_string())
             .bind(rmp_serde::to_vec(&record).map_err(SqlxStoreError::Encode)?)
-            .bind(record.expiry_date)
+            .bind(record.expiry_date()?)
             .execute(conn)
             .await
             .map_err(SqlxStoreError::Sqlx)?;
@@ -205,7 +205,7 @@ impl SessionStore for MySqlStore {
         );
         let data: Option<(Vec<u8>,)> = sqlx::query_as(&query)
             .bind(session_id.to_string())
-            .bind(OffsetDateTime::now_utc())
+            .bind(now())
             .fetch_optional(&self.pool)
             .await
             .map_err(SqlxStoreError::Sqlx)?;

--- a/sqlx-store/src/time.rs
+++ b/sqlx-store/src/time.rs
@@ -1,0 +1,44 @@
+use crate::SqlxStoreError;
+use tower_sessions_core::session::Record;
+
+#[cfg(feature = "sqlx-chrono")]
+use chrono::{DateTime, Utc};
+
+#[cfg(feature = "sqlx-time")]
+use time::OffsetDateTime;
+
+#[cfg(feature = "sqlx-time")]
+pub(crate) fn now() -> OffsetDateTime {
+    OffsetDateTime::now_utc()
+}
+
+#[cfg(feature = "sqlx-chrono")]
+pub(crate) fn now() -> DateTime<Utc> {
+    Utc::now()
+}
+
+pub(crate) trait ExpirationTime {
+    #[cfg(feature = "sqlx-time")]
+    fn expiry_date(&self) -> Result<OffsetDateTime, SqlxStoreError>;
+
+    #[cfg(feature = "sqlx-chrono")]
+    fn expiry_date(&self) -> Result<DateTime<Utc>, SqlxStoreError>;
+}
+
+impl ExpirationTime for Record {
+    #[cfg(feature = "sqlx-time")]
+    fn expiry_date(&self) -> Result<OffsetDateTime, SqlxStoreError> {
+        Ok(self.expiry_date)
+    }
+
+    #[cfg(feature = "sqlx-chrono")]
+    fn expiry_date(&self) -> Result<DateTime<Utc>, SqlxStoreError> {
+        DateTime::from_timestamp(
+            self.expiry_date.unix_timestamp(),
+            self.expiry_date.nanosecond(),
+        )
+        .ok_or(SqlxStoreError::Sqlx(sqlx::Error::InvalidArgument(
+            "fail to convert date time".to_string(),
+        )))
+    }
+}


### PR DESCRIPTION
There is a problem to use `tower-sessions-sqlx-store` if you use `sqlx` with `chrono` feature, because `tower-sessions-sqlx-store` adds the `time` feature dependency for `sqlx` into your project.
And it is not allowed to use `time` & `chrono` features simultaneously for `sqlx`.

This PR resolves this issue and allows to use `sqlx` with `time` or `chrono` feature as in your project by introducing new features here:
- `sqlx-time`
- `sqlx-chrono`

User MUST to use the only one of these features, in other case the crate is empty (without any of these features or if they both are added).

Also, now the `default` feature is `sqlx-time` for backward compatibility. Projects that already use `tower-sessions-sqlx-store` don't need to change anything (only if they don't use `default-features = false`).