### PR TITLE
Fix bool parse error

### DIFF
--- a/redis-store/src/lib.rs
+++ b/redis-store/src/lib.rs
@@ -99,7 +99,7 @@ impl<C: KeysInterface + Send + Sync> RedisStore<C> {
             record.expiry_date,
         )));
 
-        Ok(self
+        let result: Option<String> = self
             .client
             .set(
                 self.get_key(&record.id),
@@ -111,7 +111,9 @@ impl<C: KeysInterface + Send + Sync> RedisStore<C> {
                 false,
             )
             .await
-            .map_err(RedisStoreError::Redis)?)
+            .map_err(RedisStoreError::Redis)?;
+
+        Ok(result.is_some())
     }
 }
 


### PR DESCRIPTION
Fixes #19

Redis returns null when the operation is aborted because of the XX option. This can't be parsed into a `bool`. An alternative workaround is to enable the `default-nil-types` feature on `fred` but that's not something a crate like this should require of its consumers.