### PR TITLE
fix: disable sqlx default features to avoid native-tls

### DIFF
--- a/sqlx-store/Cargo.toml
+++ b/sqlx-store/Cargo.toml
@@ -20,7 +20,7 @@ mysql = ["sqlx/mysql"]
 [dependencies]
 async-trait = "0.1.77"
 rmp-serde = "1.1.2"
-sqlx = { version = "0.8.0", features = ["time", "runtime-tokio"] }
+sqlx = { version = "0.8.0", default-features = false, features = ["time", "runtime-tokio"] }
 thiserror = "1.0.56"
 time = "0.3.31"
 tower-sessions-core = { version = "0.15.0", features = ["deletion-task"] }


### PR DESCRIPTION
sqlx's default features include `tls-native-tls` which pulls in `openssl-sys`. This breaks musl cross-compilation and forces the openssl dependency on consumers who only want rustls.

Consumers already specify their preferred TLS backend (e.g. `tls-rustls`) via their own sqlx dependency — Cargo's feature unification ensures it propagates. The session store itself doesn't need any specific TLS backend.

One-line change: adds `default-features = false` to the sqlx dependency.