### PR TITLE
Add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,29 @@
+# Security Policy
+
+## Supported Versions
+
+Security fixes are applied to the latest code on the `main` branch.
+
+## Reporting a Vulnerability
+
+Please do not report suspected vulnerabilities in public GitHub issues or pull requests.
+
+Instead, use GitHub's private vulnerability reporting flow for this repository:
+
+<https://github.com/maxcountryman/tower-sessions-stores/security/advisories/new>
+
+If that flow is unavailable to you, email `hello@maxcountryman.com` with the details instead.
+
+Please include:
+
+- the affected crate or store
+- the version, commit, or dependency set you tested
+- impact and any attack scenario you identified
+- steps to reproduce, proof of concept, or logs
+- any suggested fix or mitigation, if you have one
+
+Reports are reviewed on a best-effort basis. Please avoid public disclosure until the issue has been investigated and a fix or coordinated disclosure plan is available.
+
+## Non-Security Issues
+
+For bug reports, feature requests, and general support questions, please open a regular GitHub issue.


### PR DESCRIPTION
## Summary
- add a root `SECURITY.md` with a documented vulnerability disclosure process
- direct reporters to GitHub private vulnerability reporting instead of public issues or pull requests
- include a fallback email address and the key details needed to triage a report

## Why
Issue #84 asks for a clear responsible disclosure path so downstream users and security auditors can see how vulnerabilities should be reported without exposing them publicly.

This keeps the change minimal while still documenting where reports should go and what information helps with triage.

Closes #84
