### PR TITLE
docs: add SECURITY.md with vulnerability disclosure policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,7 @@ This is a static catalog of session stores for [`tower-sessions`](https://github
 
 > [!NOTE]
 > While these stores are maintained, we will not be adding additional stores here and instead encourage folks to publish their own stores by implementing [`SessionStore`](https://docs.rs/tower-sessions/latest/tower_sessions/trait.SessionStore.html).
+
+## Security
+
+Please see [SECURITY.md](SECURITY.md) for our vulnerability disclosure policy and how to report security issues responsibly.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Supported Versions
 
-We support the latest commit on the `main` branch.
+We support the latest published version on crates.io.
 
 ## Reporting a Vulnerability
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,41 @@
+# Security Policy
+
+## Supported Versions
+
+We support the latest commit on the `main` branch.
+
+## Reporting a Vulnerability
+
+The preferred way to report a security vulnerability is through GitHub's private vulnerability reporting feature:
+
+1. Go to the repository's **Security** tab.
+2. Click **"Report a vulnerability"**.
+3. Provide as much detail as possible (description, reproduction steps, impact, affected versions).
+
+**Alternative contact**: Open a private discussion with the maintainer via GitHub or email the address listed in the repository owner profile.
+
+We will:
+- Acknowledge receipt of your report within **5 business days**.
+- Work with you to understand and resolve the issue.
+- Credit you in the release notes / advisory (unless you prefer to remain anonymous).
+
+## Disclosure Policy
+
+- We follow **coordinated responsible disclosure**.
+- Please allow **90 days** from the initial report before public disclosure.
+- We aim to release patches for confirmed vulnerabilities as quickly as possible.
+
+## Scope
+
+This policy covers the source code, documentation, and configuration files in **this repository** (`tower-sessions-stores`).
+
+**Out of scope**:
+- Issues in third-party dependencies (report to their respective projects)
+- The main `tower-sessions` crate (see its own security policy at https://github.com/maxcountryman/tower-sessions)
+- Social engineering or physical attacks
+
+## Bug Bounty
+
+This project does not currently run a paid bug bounty program. We are grateful for responsible security research and will publicly acknowledge high-quality reports.
+
+Thank you for helping keep the Rust web ecosystem secure!


### PR DESCRIPTION
## Summary
Implements the security disclosure policy requested in #84.

- Adds `SECURITY.md` at the repository root with:
  - Supported versions
  - Preferred reporting via GitHub private vulnerability reports
  - 5 business day acknowledgement + 90-day coordinated disclosure
  - Clear scope and out-of-scope items
  - Note that there is currently no paid bug bounty (common for small crates)

- Updates `README.md` with a "Security" section linking to the new policy.

## Why this matters
Small but important signal for downstream users and security researchers. GitHub and many dependency scanners now flag repos without a security policy.

## Verification
- Follows the spirit of the issue and common Rust / GitHub practices.
- No code changes, purely documentation.

Closes #84

---

**Maintainer note**: If you'd like any tweaks (different contact method, GPG key, different disclosure window, etc.), just let me know and I'll update the PR immediately. Thanks for the great crates!