### PR TITLE
Update sqlx to 0.9.0

### DIFF
--- a/sqlx-store/Cargo.toml
+++ b/sqlx-store/Cargo.toml
@@ -20,7 +20,7 @@ mysql = ["sqlx/mysql"]
 [dependencies]
 async-trait = "0.1.77"
 rmp-serde = "1.1.2"
-sqlx = { version = "0.8.0", features = ["time", "runtime-tokio"] }
+sqlx = { version = "0.9.0", features = ["time", "runtime-tokio"] }
 thiserror = "2.0.18"
 time = "0.3.31"
 tower-sessions-core = { version = "0.15.0", features = ["deletion-task"] }

--- a/sqlx-store/src/mysql_store.rs
+++ b/sqlx-store/src/mysql_store.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use sqlx::{MySqlConnection, MySqlPool};
+use sqlx::{AssertSqlSafe, MySqlConnection, MySqlPool};
 use time::OffsetDateTime;
 use tower_sessions_core::{
     session::{Id, Record},
@@ -87,13 +87,13 @@ impl MySqlStore {
     pub async fn migrate(&self) -> sqlx::Result<()> {
         let mut tx = self.pool.begin().await?;
 
-        let create_schema_query = format!(
+        let create_schema_query = AssertSqlSafe(format!(
             "create schema if not exists {schema_name}",
             schema_name = self.schema_name,
-        );
-        sqlx::query(&create_schema_query).execute(&mut *tx).await?;
+        ));
+        sqlx::query(create_schema_query).execute(&mut *tx).await?;
 
-        let create_table_query = format!(
+        let create_table_query = AssertSqlSafe(format!(
             r#"
             create table if not exists `{schema_name}`.`{table_name}`
             (
@@ -104,8 +104,8 @@ impl MySqlStore {
             "#,
             schema_name = self.schema_name,
             table_name = self.table_name
-        );
-        sqlx::query(&create_table_query).execute(&mut *tx).await?;
+        ));
+        sqlx::query(create_table_query).execute(&mut *tx).await?;
 
         tx.commit().await?;
 
@@ -113,15 +113,15 @@ impl MySqlStore {
     }
 
     async fn id_exists(&self, conn: &mut MySqlConnection, id: &Id) -> session_store::Result<bool> {
-        let query = format!(
+        let query = AssertSqlSafe(format!(
             r#"
             select exists(select 1 from `{schema_name}`.`{table_name}` where id = ?)
             "#,
             schema_name = self.schema_name,
             table_name = self.table_name
-        );
+        ));
 
-        Ok(sqlx::query_scalar(&query)
+        Ok(sqlx::query_scalar(query)
             .bind(id.to_string())
             .fetch_one(conn)
             .await
@@ -133,7 +133,7 @@ impl MySqlStore {
         conn: &mut MySqlConnection,
         record: &Record,
     ) -> session_store::Result<()> {
-        let query = format!(
+        let query = AssertSqlSafe(format!(
             r#"
             insert into `{schema_name}`.`{table_name}`
               (id, data, expiry_date) values (?, ?, ?)
@@ -143,8 +143,8 @@ impl MySqlStore {
             "#,
             schema_name = self.schema_name,
             table_name = self.table_name
-        );
-        sqlx::query(&query)
+        ));
+        sqlx::query(query)
             .bind(record.id.to_string())
             .bind(rmp_serde::to_vec(&record).map_err(SqlxStoreError::Encode)?)
             .bind(record.expiry_date)
@@ -158,15 +158,15 @@ impl MySqlStore {
 #[async_trait]
 impl ExpiredDeletion for MySqlStore {
     async fn delete_expired(&self) -> session_store::Result<()> {
-        let query = format!(
+        let query = AssertSqlSafe(format!(
             r#"
             delete from `{schema_name}`.`{table_name}`
             where expiry_date < utc_timestamp()
             "#,
             schema_name = self.schema_name,
             table_name = self.table_name
-        );
-        sqlx::query(&query)
+        ));
+        sqlx::query(query)
             .execute(&self.pool)
             .await
             .map_err(SqlxStoreError::Sqlx)?;
@@ -195,15 +195,15 @@ impl SessionStore for MySqlStore {
     }
 
     async fn load(&self, session_id: &Id) -> session_store::Result<Option<Record>> {
-        let query = format!(
+        let query = AssertSqlSafe(format!(
             r#"
             select data from `{schema_name}`.`{table_name}`
             where id = ? and expiry_date > ?
             "#,
             schema_name = self.schema_name,
             table_name = self.table_name
-        );
-        let data: Option<(Vec<u8>,)> = sqlx::query_as(&query)
+        ));
+        let data: Option<(Vec<u8>,)> = sqlx::query_as(query)
             .bind(session_id.to_string())
             .bind(OffsetDateTime::now_utc())
             .fetch_optional(&self.pool)
@@ -220,12 +220,12 @@ impl SessionStore for MySqlStore {
     }
 
     async fn delete(&self, session_id: &Id) -> session_store::Result<()> {
-        let query = format!(
+        let query = AssertSqlSafe(format!(
             r#"delete from `{schema_name}`.`{table_name}` where id = ?"#,
             schema_name = self.schema_name,
             table_name = self.table_name
-        );
-        sqlx::query(&query)
+        ));
+        sqlx::query(query)
             .bind(session_id.to_string())
             .execute(&self.pool)
             .await

--- a/sqlx-store/src/postgres_store.rs
+++ b/sqlx-store/src/postgres_store.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use sqlx::{PgConnection, PgPool};
+use sqlx::{AssertSqlSafe, PgConnection, PgPool};
 use time::OffsetDateTime;
 use tower_sessions_core::{
     session::{Id, Record},
@@ -87,14 +87,14 @@ impl PostgresStore {
     pub async fn migrate(&self) -> sqlx::Result<()> {
         let mut tx = self.pool.begin().await?;
 
-        let create_schema_query = format!(
+        let create_schema_query = AssertSqlSafe(format!(
             r#"create schema if not exists "{schema_name}""#,
             schema_name = self.schema_name,
-        );
+        ));
         // Concurrent create schema may fail due to duplicate key violations.
         //
         // This works around that by assuming the schema must exist on such an error.
-        if let Err(err) = sqlx::query(&create_schema_query).execute(&mut *tx).await {
+        if let Err(err) = sqlx::query(create_schema_query).execute(&mut *tx).await {
             if !err
                 .to_string()
                 .contains("duplicate key value violates unique constraint")
@@ -105,7 +105,7 @@ impl PostgresStore {
             return Ok(());
         }
 
-        let create_table_query = format!(
+        let create_table_query = AssertSqlSafe(format!(
             r#"
             create table if not exists "{schema_name}"."{table_name}"
             (
@@ -116,8 +116,8 @@ impl PostgresStore {
             "#,
             schema_name = self.schema_name,
             table_name = self.table_name
-        );
-        sqlx::query(&create_table_query).execute(&mut *tx).await?;
+        ));
+        sqlx::query(create_table_query).execute(&mut *tx).await?;
 
         tx.commit().await?;
 
@@ -125,15 +125,15 @@ impl PostgresStore {
     }
 
     async fn id_exists(&self, conn: &mut PgConnection, id: &Id) -> session_store::Result<bool> {
-        let query = format!(
+        let query = AssertSqlSafe(format!(
             r#"
             select exists(select 1 from "{schema_name}"."{table_name}" where id = $1)
             "#,
             schema_name = self.schema_name,
             table_name = self.table_name
-        );
+        ));
 
-        Ok(sqlx::query_scalar(&query)
+        Ok(sqlx::query_scalar(query)
             .bind(id.to_string())
             .fetch_one(conn)
             .await
@@ -145,7 +145,7 @@ impl PostgresStore {
         conn: &mut PgConnection,
         record: &Record,
     ) -> session_store::Result<()> {
-        let query = format!(
+        let query = AssertSqlSafe(format!(
             r#"
             insert into "{schema_name}"."{table_name}" (id, data, expiry_date)
             values ($1, $2, $3)
@@ -156,8 +156,8 @@ impl PostgresStore {
             "#,
             schema_name = self.schema_name,
             table_name = self.table_name
-        );
-        sqlx::query(&query)
+        ));
+        sqlx::query(query)
             .bind(record.id.to_string())
             .bind(rmp_serde::to_vec(&record).map_err(SqlxStoreError::Encode)?)
             .bind(record.expiry_date)
@@ -172,15 +172,15 @@ impl PostgresStore {
 #[async_trait]
 impl ExpiredDeletion for PostgresStore {
     async fn delete_expired(&self) -> session_store::Result<()> {
-        let query = format!(
+        let query = AssertSqlSafe(format!(
             r#"
             delete from "{schema_name}"."{table_name}"
             where expiry_date < (now() at time zone 'utc')
             "#,
             schema_name = self.schema_name,
             table_name = self.table_name
-        );
-        sqlx::query(&query)
+        ));
+        sqlx::query(query)
             .execute(&self.pool)
             .await
             .map_err(SqlxStoreError::Sqlx)?;
@@ -209,15 +209,15 @@ impl SessionStore for PostgresStore {
     }
 
     async fn load(&self, session_id: &Id) -> session_store::Result<Option<Record>> {
-        let query = format!(
+        let query = AssertSqlSafe(format!(
             r#"
             select data from "{schema_name}"."{table_name}"
             where id = $1 and expiry_date > $2
             "#,
             schema_name = self.schema_name,
             table_name = self.table_name
-        );
-        let record_value: Option<(Vec<u8>,)> = sqlx::query_as(&query)
+        ));
+        let record_value: Option<(Vec<u8>,)> = sqlx::query_as(query)
             .bind(session_id.to_string())
             .bind(OffsetDateTime::now_utc())
             .fetch_optional(&self.pool)
@@ -234,12 +234,12 @@ impl SessionStore for PostgresStore {
     }
 
     async fn delete(&self, session_id: &Id) -> session_store::Result<()> {
-        let query = format!(
+        let query = AssertSqlSafe(format!(
             r#"delete from "{schema_name}"."{table_name}" where id = $1"#,
             schema_name = self.schema_name,
             table_name = self.table_name
-        );
-        sqlx::query(&query)
+        ));
+        sqlx::query(query)
             .bind(session_id.to_string())
             .execute(&self.pool)
             .await

--- a/sqlx-store/src/sqlite_store.rs
+++ b/sqlx-store/src/sqlite_store.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use sqlx::{sqlite::SqlitePool, SqliteConnection};
+use sqlx::{sqlite::SqlitePool, AssertSqlSafe, SqliteConnection};
 use time::OffsetDateTime;
 use tower_sessions_core::{
     session::{Id, Record},
@@ -53,7 +53,7 @@ impl SqliteStore {
 
     /// Migrate the session schema.
     pub async fn migrate(&self) -> sqlx::Result<()> {
-        let query = format!(
+        let query = AssertSqlSafe(format!(
             r#"
             create table if not exists {}
             (
@@ -63,8 +63,8 @@ impl SqliteStore {
             )
             "#,
             self.table_name
-        );
-        sqlx::query(&query).execute(&self.pool).await?;
+        ));
+        sqlx::query(query).execute(&self.pool).await?;
         Ok(())
     }
 
@@ -73,14 +73,14 @@ impl SqliteStore {
         conn: &mut SqliteConnection,
         record: &Record,
     ) -> session_store::Result<bool> {
-        let query = format!(
+        let query = AssertSqlSafe(format!(
             r#"
             insert or abort into {table_name}
               (id, data, expiry_date) values (?, ?, ?)
             "#,
             table_name = self.table_name
-        );
-        let res = sqlx::query(&query)
+        ));
+        let res = sqlx::query(query)
             .bind(record.id.to_string())
             .bind(rmp_serde::to_vec(record).map_err(SqlxStoreError::Encode)?)
             .bind(record.expiry_date)
@@ -99,7 +99,7 @@ impl SqliteStore {
         conn: &mut SqliteConnection,
         record: &Record,
     ) -> session_store::Result<()> {
-        let query = format!(
+        let query = AssertSqlSafe(format!(
             r#"
             insert into {table_name}
               (id, data, expiry_date) values (?, ?, ?)
@@ -108,8 +108,8 @@ impl SqliteStore {
               expiry_date = excluded.expiry_date
             "#,
             table_name = self.table_name
-        );
-        sqlx::query(&query)
+        ));
+        sqlx::query(query)
             .bind(record.id.to_string())
             .bind(rmp_serde::to_vec(record).map_err(SqlxStoreError::Encode)?)
             .bind(record.expiry_date)
@@ -124,14 +124,14 @@ impl SqliteStore {
 #[async_trait]
 impl ExpiredDeletion for SqliteStore {
     async fn delete_expired(&self) -> session_store::Result<()> {
-        let query = format!(
+        let query = AssertSqlSafe(format!(
             r#"
             delete from {table_name}
             where datetime(expiry_date) < datetime('now')
             "#,
             table_name = self.table_name
-        );
-        sqlx::query(&query)
+        ));
+        sqlx::query(query)
             .execute(&self.pool)
             .await
             .map_err(SqlxStoreError::Sqlx)?;
@@ -159,14 +159,14 @@ impl SessionStore for SqliteStore {
     }
 
     async fn load(&self, session_id: &Id) -> session_store::Result<Option<Record>> {
-        let query = format!(
+        let query = AssertSqlSafe(format!(
             r#"
             select data from {}
             where id = ? and expiry_date > ?
             "#,
             self.table_name
-        );
-        let data: Option<(Vec<u8>,)> = sqlx::query_as(&query)
+        ));
+        let data: Option<(Vec<u8>,)> = sqlx::query_as(query)
             .bind(session_id.to_string())
             .bind(OffsetDateTime::now_utc())
             .fetch_optional(&self.pool)
@@ -183,13 +183,13 @@ impl SessionStore for SqliteStore {
     }
 
     async fn delete(&self, session_id: &Id) -> session_store::Result<()> {
-        let query = format!(
+        let query = AssertSqlSafe(format!(
             r#"
             delete from {} where id = ?
             "#,
             self.table_name
-        );
-        sqlx::query(&query)
+        ));
+        sqlx::query(query)
             .bind(session_id.to_string())
             .execute(&self.pool)
             .await


### PR DESCRIPTION
This updates sqlx to `0.9.0` and simply wraps all the dynamic queries with [`AssertSqlSafe`](https://docs.rs/sqlx/latest/sqlx/struct.AssertSqlSafe.html) to ignore the errors stating that the queries should be audited for possible SQL injection.

Aside from that no changes seem to be needed, all tests still pass and nothing else shows up in `cargo check`/`cargo clippy`.